### PR TITLE
added include_top option to model

### DIFF
--- a/efficientnet_pytorch_3d/model.py
+++ b/efficientnet_pytorch_3d/model.py
@@ -190,11 +190,12 @@ class EfficientNet3D(nn.Module):
         # Convolution layers
         x = self.extract_features(inputs)
 
-        # Pooling and final linear layer
-        x = self._avg_pooling(x)
-        x = x.view(bs, -1)
-        x = self._dropout(x)
-        x = self._fc(x)
+        if self._global_params.include_top:
+            # Pooling and final linear layer
+            x = self._avg_pooling(x)
+            x = x.view(bs, -1)
+            x = self._dropout(x)
+            x = self._fc(x)
         return x
 
     @classmethod

--- a/efficientnet_pytorch_3d/utils.py
+++ b/efficientnet_pytorch_3d/utils.py
@@ -21,7 +21,7 @@ from torch.utils import model_zoo
 GlobalParams = collections.namedtuple('GlobalParams', [
     'batch_norm_momentum', 'batch_norm_epsilon', 'dropout_rate',
     'num_classes', 'width_coefficient', 'depth_coefficient',
-    'depth_divisor', 'min_depth', 'drop_connect_rate', 'image_size'])
+    'depth_divisor', 'min_depth', 'drop_connect_rate', 'image_size', 'include_top'])
 
 # Parameters for an individual model block
 BlockArgs = collections.namedtuple('BlockArgs', [
@@ -254,7 +254,7 @@ class BlockDecoder(object):
 
 
 def efficientnet3d(width_coefficient=None, depth_coefficient=None, dropout_rate=0.2,
-                 drop_connect_rate=0.2, image_size=None, num_classes=1000):
+                 drop_connect_rate=0.2, image_size=None, num_classes=1000, include_top=True):
     """ Creates a efficientnet model. """
 
     blocks_args = [
@@ -277,6 +277,7 @@ def efficientnet3d(width_coefficient=None, depth_coefficient=None, dropout_rate=
         depth_divisor=8,
         min_depth=None,
         image_size=image_size,
+        include_top=include_top,
     )
 
     return blocks_args, global_params


### PR DESCRIPTION
Hi there,

I've added extra functionality such that a user can now specify whether to include the last layers of the network (avgpool + dropout + fc + swish) or to omit these last layers instead. This is especially handy if one wants to use the efficientnet just for feature extraction and wants to build a different network on top of it.

A simple minimum working example is given below:

```
from efficientnet_pytorch_3d import EfficientNet3D
from efficientnet_pytorch_3d.utils import MemoryEfficientSwish
from torchsummary import summary
from torch import nn

# A model with the final layers
model = EfficientNet3D.from_name("efficientnet-b0", override_params={'num_classes':2, 'include_top':True}, in_channels=1)
model.to('cuda')
summary(model,input_size=(1,100,100,100))

# A model without the final layers
model = EfficientNet3D.from_name("efficientnet-b0", override_params={'num_classes':2, 'include_top':False}, in_channels=1)
model.to('cuda')
summary(model,input_size=(1,100,100,100))

# A custom model build on top of the feature extraction part of EfficientNet
model = EfficientNet3D.from_name("efficientnet-b0", override_params={'num_classes':2, 'include_top':False}, in_channels=1)
new_model = nn.Sequential(model,nn.AdaptiveAvgPool3d(1),nn.Dropout(0.2),nn.Flatten(),nn.Linear(1280,100),nn.Linear(100,2),MemoryEfficientSwish())

new_model.to('cuda')
summary(new_model,input_size=(1,100,100,100))
```