### PR TITLE
Fix incorrect block_arg

### DIFF
--- a/efficientnet_pytorch_3d/utils.py
+++ b/efficientnet_pytorch_3d/utils.py
@@ -258,7 +258,7 @@ def efficientnet3d(width_coefficient=None, depth_coefficient=None, dropout_rate=
     """ Creates a efficientnet model. """
 
     blocks_args = [
-        'r1_k3_s222_e1_i32_o16_se0.25', 'r2_k3_s222_e6_i16_o24_se0.25',
+        'r1_k3_s111_e1_i32_o16_se0.25', 'r2_k3_s222_e6_i16_o24_se0.25',
         'r2_k5_s222_e6_i24_o40_se0.25', 'r3_k3_s222_e6_i40_o80_se0.25',
         'r3_k5_s111_e6_i80_o112_se0.25', 'r4_k5_s222_e6_i112_o192_se0.25',
         'r1_k3_s111_e6_i192_o320_se0.25',


### PR DESCRIPTION
According to the original paper, the first MBConv operation should keep the input resolution. Hence, it should have stride 1. In fact, the [original EfficientNet repository](https://github.com/lukemelas/EfficientNet-PyTorch/blob/master/efficientnet_pytorch/utils.py#L503)'s first block_arg is: `r1_k3_s11_e1_i32_o16_se0.25`